### PR TITLE
fix: certbot 절대경로 적용

### DIFF
--- a/src/routes/certbot.ts
+++ b/src/routes/certbot.ts
@@ -4,12 +4,12 @@ import fs from 'fs';
 const router = Router();
 
 // .well-known 폴더 생성
-const wellKnownPath = '.well-known/acme-challenge';
+const wellKnownPath = '/tmp/.well-known/acme-challenge';
 if (!fs.existsSync(wellKnownPath)) {
     fs.mkdirSync(wellKnownPath, { recursive: true });
 }
 
 // certbot 검증용 라우트
-router.use('/.well-known', express.static('.well-known'));
+router.use('/.well-known', express.static('/tmp/.well-known'));
 
 export default router;


### PR DESCRIPTION
CICD 중 경로가 복잡해져 상대경로를 절대경로로 바꾼다.

bss-21-certbot-router